### PR TITLE
Hackney is now available on hex.pm

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,13 @@ end
 defp deps do
   [
     {:discovery, "~> 0.1.0"},
-    {:hackney, github: "benoitc/hackney"},
+    {:hackney, "~> 0.13.1"},
   ]
 end
 ```
 
 Then run `mix deps.get` in your shell to fetch the dependencies.
 
-> NOTE: Hackney is currently not hosted on [Hex](https://hex.pm) so it must be added explicitly as a github dependency
 
 ## Usage
 


### PR DESCRIPTION
See the package listing at:
https://hex.pm/packages/hackney
