### PR TITLE
Add handler for invoking node on_connect/on_disconnect functions

### DIFF
--- a/lib/discovery/handler/behaviour.ex
+++ b/lib/discovery/handler/behaviour.ex
@@ -16,8 +16,12 @@ defmodule Discovery.Handler.Behaviour do
       # GenEvent callbacks
       #
 
-      def handle_event({:services, services}, state) do
+      def handle_event({:services, services}, state) when is_list(services) do
         handle_services(services, state)
+      end
+
+      def handle_event({:services, service}, state) do
+        handle_services([service], state)
       end
     end
   end

--- a/lib/discovery/heartbeat.ex
+++ b/lib/discovery/heartbeat.ex
@@ -50,7 +50,6 @@ defmodule Discovery.Heartbeat do
     case service_name(check_id) do
       {:ok, service} ->
         :ok = Discovery.register_app(service)
-        :ok = Discovery.Directory.add(Node.self, service)
         {:ok, %{timer: nil, check_id: check_id, interval: interval, service: service}, 0}
       error ->
         {:stop, error}

--- a/lib/discovery/node_connector.ex
+++ b/lib/discovery/node_connector.ex
@@ -14,17 +14,26 @@ defmodule Discovery.NodeConnector do
 
   use GenServer
   alias Discovery.Directory
+  alias Discovery.NodeConnector
 
-  @name Discovery.NodeConnector
+  @name __MODULE__
 
   @spec start_link :: GenServer.on_start
   def start_link do
     GenServer.start_link(__MODULE__, [], name: @name)
   end
 
-  @spec start_link([atom]) :: GenServer.on_start
+  @spec start_link([atom] | [{atom, list}]) :: GenServer.on_start
   def start_link(handlers) do
     GenServer.start_link(__MODULE__, handlers, name: @name)
+  end
+
+  @doc """
+  Register a `NodeConnector.Handler` to be invoked on successful node connect and disconnect.
+  """
+  @spec add_handler(atom, list) :: {:ok, {atom, reference}} | {:error, term}
+  def add_handler(module, args \\ []) do
+    GenServer.call(@name, {:add_handler, module, args})
   end
 
   @doc """
@@ -47,40 +56,54 @@ defmodule Discovery.NodeConnector do
     GenServer.call(@name, {:disconnect, node, services})
   end
 
+  @doc """
+  Remove a registered `NodeConnector.Handler`.
+  """
+  @spec remove_handler(atom, reference) :: term | {:error, term}
+  def remove_handler(module, ref) do
+    GenServer.call(@name, {:remove_handler, module, ref})
+  end
+
   #
   # Private
   #
 
-  defp attempt_connect(node, %{retry_ms: retry_ms, timers: timers} = state) do
-    Logger.debug "Attempting to connect to node: #{node}"
-    case Node.connect(node) do
-      result when result in [false, :ignored] ->
-        timer      = :erlang.send_after(retry_ms, self, {:retry_connect, node})
-        new_timers = Dict.put(timers, node, timer)
-      true ->
-        Logger.info "Connected to: #{node}"
-        case Directory.add(node, Node.self, Discovery.apps) do
-          :ok ->
-            case Dict.fetch(timers, node) do
-              {:ok, nil} ->
-                :ok
-              :error ->
-                Node.monitor(node, true)
-              {:ok, timer} ->
-                Node.monitor(node, true)
-                :erlang.cancel_timer(timer)
-            end
-            new_timers = Dict.put(timers, node, nil)
-          {:error, _} ->
-            timer      = :erlang.send_after(retry_ms, self, {:retry_connect, node})
-            new_timers = Dict.put(timers, node, timer)
-        end
-    end
+  defp attempt_connect(node, %{em: em, retry_ms: retry_ms, timers: timers} = state) do
+    if node == Node.self do
+      NodeConnector.Handler.notify_connect(em, node)
+      state
+    else
+      Logger.debug "Attempting to connect to node: #{node}"
+      case Node.connect(node) do
+        result when result in [false, :ignored] ->
+          timer      = :erlang.send_after(retry_ms, self, {:retry_connect, node})
+          new_timers = Dict.put(timers, node, timer)
+        true ->
+          Logger.info "Connected to: #{node}"
+          NodeConnector.Handler.notify_connect(em, node)
+          case Directory.add(node, Node.self, Discovery.apps) do
+            :ok ->
+              case Dict.fetch(timers, node) do
+                {:ok, nil} ->
+                  :ok
+                :error ->
+                  Node.monitor(node, true)
+                {:ok, timer} ->
+                  Node.monitor(node, true)
+                  :erlang.cancel_timer(timer)
+              end
+              new_timers = Dict.put(timers, node, nil)
+            {:error, _} ->
+              timer      = :erlang.send_after(retry_ms, self, {:retry_connect, node})
+              new_timers = Dict.put(timers, node, timer)
+          end
+      end
 
-    %{state | timers: new_timers}
+      %{state | timers: new_timers}
+    end
   end
 
-  defp attempt_disconnect(node, %{timers: timers} = state) do
+  defp attempt_disconnect(node, %{em: em, timers: timers} = state) do
     Logger.debug "Attempting to disconnect from node: #{node}"
     case Dict.pop(timers, node) do
       {nil, new_timers} ->
@@ -98,20 +121,49 @@ defmodule Discovery.NodeConnector do
 
     Node.disconnect(node)
     Logger.info "Disconnected from: #{node}"
+    NodeConnector.Handler.notify_disconnect(em, node)
 
     %{state | timers: new_timers}
+  end
+
+  defp register_handler(em, module, args \\ []) do
+    ref = make_ref()
+    case GenEvent.add_handler(em, {module, ref}, args) do
+      :ok   -> {:ok, ref}
+      error -> error
+    end
+  end
+
+  defp unregister_handler(em, module, ref) do
+    GenEvent.remove_handler(em, {module, ref}, [])
   end
 
   #
   # GenServer callbacks
   #
 
-  def init([]) do
-    retry_ms = Application.get_env(:discovery, :retry_connect_ms, 5000)
-    {:ok, %{retry_ms: retry_ms, timers: %{}}}
+  def init(handlers) do
+    retry_ms  = Application.get_env(:discovery, :retry_connect_ms, 5000)
+    {:ok, em} = GenEvent.start_link
+    Enum.each handlers, fn
+      {module, args} ->
+        register_handler(em, module, args)
+      module when is_atom(module) ->
+        register_handler(em, module)
+    end
+    {:ok, %{retry_ms: retry_ms, timers: %{}, em: em}}
   end
 
-  def handle_call({:connect, node, service}, _from, state) do
+  def handle_call({:add_handler, module, args}, _, %{em: em} = state) do
+    case register_handler(em, module, args) do
+      {:ok, ref} ->
+        {:reply, {:ok, {module, ref}}, state}
+      error ->
+        {:reply, error, state}
+    end
+  end
+
+  def handle_call({:connect, node, service}, _, state) do
     case Directory.has_node?(node) do
       true ->
         {:reply, :ok, state}
@@ -122,7 +174,7 @@ defmodule Discovery.NodeConnector do
     end
   end
 
-  def handle_call({:disconnect, node, services}, _from, state) do
+  def handle_call({:disconnect, node, services}, _, state) do
     :ok = Directory.drop(node, services)
     case Directory.has_node?(node) do
       true ->
@@ -131,6 +183,10 @@ defmodule Discovery.NodeConnector do
         new_state = attempt_disconnect(node, state)
         {:reply, :ok, new_state}
     end
+  end
+
+  def handle_call({:remove_handler, module, ref}, _, %{em: em} = state) do
+    {:reply, unregister_handler(em, module, ref), state}
   end
 
   def handle_info({:retry_connect, node}, state) do

--- a/lib/discovery/node_connector/handler.ex
+++ b/lib/discovery/node_connector/handler.ex
@@ -1,0 +1,44 @@
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2014 Undead Labs, LLC
+#
+
+defmodule Discovery.NodeConnector.Handler do
+  use Behaviour
+
+  @spec notify_connect(pid, node) :: :ok
+  def notify_connect(em, node) do
+    GenEvent.notify(em, {:connect, node})
+  end
+
+  @spec notify_disconnect(pid, node) :: :ok
+  def notify_disconnect(em, node) do
+    GenEvent.notify(em, {:disconnect, node})
+  end
+
+  defmacro __using__(_) do
+    quote do
+      @behaviour unquote(__MODULE__)
+      use GenEvent
+      alias Discovery.Directory
+
+      #
+      # GenEvent callbacks
+      #
+
+      def handle_event({:connect, node}, state) do
+        on_connect(node, Directory.services(node))
+        {:ok, state}
+      end
+
+      def handle_event({:disconnect, node}, state) do
+        on_disconnect(node, Directory.services(node))
+        {:ok, state}
+      end
+    end
+  end
+
+  defcallback on_connect(node :: node, service :: binary)
+  defcallback on_disconnect(node :: node, services :: [binary])
+end

--- a/lib/discovery/util.ex
+++ b/lib/discovery/util.ex
@@ -1,0 +1,28 @@
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2014 Undead Labs, LLC
+#
+
+defmodule Discovery.Util do
+  @moduledoc """
+  A collection of helpful functions.
+  """
+
+  @doc """
+  Determine if the given application is currently loaded and running.
+  """
+  @spec app_running?(atom) :: boolean
+  def app_running?(name) when is_binary(name), do: String.to_atom(name) |> app_running?
+  def app_running?(name) when is_atom(name) do
+    :application.which_applications |> _app_running?(name)
+  end
+
+  #
+  # Private
+  #
+
+  defp _app_running?([], _), do: false
+  defp _app_running?([app|_], name) when elem(app, 0) == name, do: true
+  defp _app_running?([_|rest], name), do: _app_running?(rest, name)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -27,6 +27,7 @@ defmodule Discovery.Mixfile do
       env: [
         retry_connect_ms: 5000,
         replica_count: 128,
+        enable_polling: true,
       ]
     ]
   end


### PR DESCRIPTION
The Discovery.NodeConnector.Handler behaviour can be implemented and passed as an argument to Discovery.Poller.start_link/2. Everytime a node is connected to, reconnected to, or disconnected from the functions each handler expose will be run.

/cc @gamepoet 
