### PR TITLE
Add docs badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,6 @@ before_script:
   - mix deps.get
 script:
   - MIX_ENV=all mix test
+after_script:
+  - mix deps.get --only docs
+  - MIX_ENV=docs mix inch.report

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Discovery
 
-[![Build Status](https://travis-ci.org/undeadlabs/discovery.png?branch=master)](https://travis-ci.org/undeadlabs/discovery)
+[![Build Status](https://travis-ci.org/undeadlabs/discovery.png?branch=master)](https://travis-ci.org/undeadlabs/discovery) [![Inline docs](http://inch-ci.org/github/undeadlabs/discovery.svg?branch=master)](http://inch-ci.org/github/undeadlabs/discovery)
 
 An OTP application for auto-discovering services with [Consul](http://www.consul.io)
 

--- a/mix.exs
+++ b/mix.exs
@@ -36,6 +36,7 @@ defmodule Discovery.Mixfile do
     [
       {:consul, "~> 0.2.0"},
       {:hash_ring_ex, "~> 1.1"},
+      {:inch_ex, only: :docs}
     ]
   end
 


### PR DESCRIPTION
Hi there,

I made a docs badge for Elixir projects. Since Elixir declared documentation to be a "first class citizen" and I already had created [Inch](http://trivelop.de/inch) for Ruby projects, I decided to try to implement "inline-docs linting" for Elixir as well.

This is what it would look like: [![Inline docs](http://inch-ci.org/github/undeadlabs/discovery.svg)](http://inch-ci.org/github/undeadlabs/discovery) (click to view status page)

The idea is to show to potential contributors that a lib/package is documented and to inspire people starting with Elixir to follow suit. The badge links to [Inch CI](http://inch-ci.org), a project that tries to raise the visibility of inline-docs to encourage aspiring programmers to document their code.  Inch CI is still relatively new (4 months old), but is also relatively succesful (badges used by 400+ Ruby projects and some Elixir projects including the [Phoenix Webframework](https://github.com/phoenixframework/phoenix) and [Plug](https://github.com/elixir-lang/plug)).

What do you think?
