### PR TITLE
Added a default "otp_name" if not defined

### DIFF
--- a/lib/discovery.ex
+++ b/lib/discovery.ex
@@ -19,10 +19,8 @@ defmodule Discovery do
     Supervisor.start_link(children, opts)
   end
 
-  defdelegate [
-    nodes(service),
-    find(service, hash),
-  ], to: Discovery.Directory
+  defdelegate nodes(service), to: Discovery.Directory
+  defdelegate find(service, hash), to: Discovery.Directory
 
   @doc """
   Returns a list of applications that this process provides.

--- a/lib/discovery.ex
+++ b/lib/discovery.ex
@@ -52,7 +52,7 @@ defmodule Discovery do
       [] ->
         fun.({:error, {:no_servers, service}})
       service_nodes ->
-        index = :random.uniform(Enum.count(service_nodes))
+        index = :rand.uniform(Enum.count(service_nodes))
         fun.({:ok, Enum.at(service_nodes, index - 1)})
     end
   end

--- a/lib/discovery/handler/node_connect.ex
+++ b/lib/discovery/handler/node_connect.ex
@@ -46,6 +46,8 @@ defmodule Discovery.Handler.NodeConnect do
   @spec connect([Service.t]) :: :ok
   def connect([]), do: :ok
   def connect([%Service{name: name, status: status} = service|rest]) when status in [@passing, @warning] do
+    # interesting that this responds with an error but does nothing with it
+    _ = 
     case otp_name(service) do
       nil ->
         {:error, :no_node_name}

--- a/lib/discovery/handler/node_connect.ex
+++ b/lib/discovery/handler/node_connect.ex
@@ -138,9 +138,16 @@ defmodule Discovery.Handler.NodeConnect do
   # Private
   #
 
-  defp otp_name(%{tags: []}), do: nil
-  defp otp_name(%{tags: tags}) when is_list(tags) do
+  defp otp_name(%{tags: [], node: node}) when node != nil do
+    %Discovery.Node{address: address, name: host} = node
+    String.to_atom(host <> "@" <> address)
+  end
+
+  defp otp_name(%{tags: tags, node: node}) when is_list(tags) do
     case Keyword.get(tags, :otp_name) do
+      nil when node != nil ->
+        %Discovery.Node{address: address, name: host} = node
+        String.to_atom(host <> "@" <> address)
       nil ->
         nil
       name when is_binary(name) ->

--- a/lib/discovery/heartbeat.ex
+++ b/lib/discovery/heartbeat.ex
@@ -68,7 +68,7 @@ defmodule Discovery.Heartbeat do
   end
 
   def handle_info(:pulse, %{check_id: check_id, interval: interval, timer: timer} = state) do
-    :erlang.cancel_timer(timer)
+    _ = :erlang.cancel_timer(timer)
     send_pulse(check_id)
     new_timer = :erlang.send_after(interval, self, :pulse)
     {:noreply, %{state | timer: new_timer}}

--- a/lib/discovery/poller.ex
+++ b/lib/discovery/poller.ex
@@ -104,11 +104,10 @@ defmodule Discovery.Poller do
     if enabled? do
       case Consul.Health.service(service) do
         {:ok, %{body: body} = response} ->
+          new_services =
           case Discovery.Service.from_health(body) do
-            [] = result ->
-              new_services = result
-            services ->
-              new_services = services
+            [] = result -> result
+            services -> services
           end
           :ok       = notify_change(new_services, state)
           new_state = %{state | services: new_services, index: consul_index(response)}
@@ -127,11 +126,10 @@ defmodule Discovery.Poller do
   def handle_info({ref, results}, %{task: %Task{ref: ref}} = state) do
     case results do
       {:ok, %{body: body} = response} ->
+        new_services =
         case Discovery.Service.from_health(body) do
-          [] = result ->
-            new_services = result
-          services ->
-            new_services = services
+          [] = result -> result
+          services -> services
         end
         :ok       = notify_change(new_services, state)
         new_state = %{state | services: new_services, index: consul_index(response)}

--- a/lib/discovery/poller.ex
+++ b/lib/discovery/poller.ex
@@ -46,7 +46,7 @@ defmodule Discovery.Poller do
     Application.get_env(:discovery, :enable_polling, true)
   end
 
-  @spec poll(binary | integer, binary) :: {:ok | :error, HTTPoison.Response.t | binary}
+  @spec poll(binary | integer, binary | atom) :: {:ok | :error, HTTPoison.Response.t | binary}
   def poll(index, service) do
     Consul.Health.service(service, index: index, wait: @wait)
   end
@@ -114,7 +114,7 @@ defmodule Discovery.Poller do
           task      = async_poll(new_state.index, service)
           {:noreply, %{new_state | task: task}}
         {:error, error} ->
-          Logger.warn "Error polling service status from Consul: #{inspect error}"
+          _ = Logger.warn "Error polling service status from Consul: #{inspect error}"
           {:noreply, state, @retry_ms}
       end
     else

--- a/lib/discovery/poller.ex
+++ b/lib/discovery/poller.ex
@@ -31,7 +31,7 @@ defmodule Discovery.Poller do
     GenServer.start_link(__MODULE__, [service, [handler]])
   end
 
-  @spec async_poll(binary | integer, binary) :: Task.t
+  @spec async_poll(binary | integer, binary | atom) :: Task.t
   def async_poll(index, service) do
     Task.async(__MODULE__, :poll, [index, service])
   end

--- a/lib/discovery/ring.ex
+++ b/lib/discovery/ring.ex
@@ -21,12 +21,10 @@ defmodule Discovery.Ring do
     HashRing.start(replicas: Application.get_env(:discovery, :replica_count, 128))
   end
 
-  defdelegate [
-    add(ring, node),
-    drop(ring, node),
-    stop(ring),
-    set_mode(ring, mode),
-  ], to: HashRing
+  defdelegate  add(ring, node),     to: HashRing
+  defdelegate  drop(ring, node),    to: HashRing
+  defdelegate  stop(ring),          to: HashRing
+  defdelegate  set_mode(ring, mode),to: HashRing
 
   @doc """
   Find a node in a service ring with the given hash key.

--- a/lib/discovery/service.ex
+++ b/lib/discovery/service.ex
@@ -48,8 +48,6 @@ defmodule Discovery.Service do
   defp extract_tags(%{"Tags" => tags}, node), do: extract_tags(tags, [], node)
   defp extract_tags([], tags, node) do
       if( nil == tags[:otp_name] ) do
-        address = node["Address"]
-        host    = node["Node"]
         [{:otp_name, node["Node"] <> "@" <> node["Address"]} | tags]
       else
           tags

--- a/lib/discovery/service.ex
+++ b/lib/discovery/service.ex
@@ -26,11 +26,11 @@ defmodule Discovery.Service do
   @spec from_health([map] | map) :: [Discovery.Service.t] | Discovery.Service.t
   def from_health([]), do: []
   def from_health(checks) when is_list(checks), do: Enum.map(checks, &from_health/1)
+  def from_health(r) when is_bitstring(r), do: from_health(:jsxn.decode(r))
   def from_health(%{"Node" => node, "Checks" => checks, "Service" => service}) do
     %__MODULE__{name: service["Service"], port: service["Port"], tags: extract_tags(service, node),
       status: extract_status(checks, service), node: %Discovery.Node{address: node["Address"], name: node["Node"]}}
   end
-
   #
   # Private API
   #

--- a/lib/discovery/service.ex
+++ b/lib/discovery/service.ex
@@ -26,7 +26,7 @@ defmodule Discovery.Service do
   @spec from_health([map] | map) :: [Discovery.Service.t] | Discovery.Service.t
   def from_health([]), do: []
   def from_health(checks) when is_list(checks), do: Enum.map(checks, &from_health/1)
-  def from_health(r) when is_bitstring(r), do: from_health(:jsxn.decode(r))
+  def from_health(r) when is_bitstring(r), do: from_health(:jsx.decode(r, [:return_maps]))
   def from_health(%{"Node" => node, "Checks" => checks, "Service" => service}) do
     %__MODULE__{name: service["Service"], port: service["Port"], tags: extract_tags(service, node),
       status: extract_status(checks, service), node: %Discovery.Node{address: node["Address"], name: node["Node"]}}
@@ -50,9 +50,10 @@ defmodule Discovery.Service do
       if( nil == tags[:otp_name] ) do
         address = node["Address"]
         host    = node["Node"]
-        tags = [{:otp_name, node["Node"] <> "@" <> node["Address"]} | tags]
+        [{:otp_name, node["Node"] <> "@" <> node["Address"]} | tags]
+      else
+          tags
       end
-      tags
   end 
   defp extract_tags([tag|rest], acc, node) do
     extract_tags(rest, [extract_tag(tag)|acc], node)

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Discovery.Mixfile do
 
   defp deps do
     [
-      {:consul, "~> 1.0"},
+      {:consul, git: "https://github.com/cjimison/consul-ex.git", branch: "master"},
       {:hash_ring_ex, "~> 1.1"},
       {:inch_ex, only: :docs}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule Discovery.Mixfile do
   defp deps do
     [
       {:consul, git: "https://github.com/cjimison/consul-ex.git", branch: "master"},
-      {:hash_ring_ex, "~> 1.1.2"},
+      {:hash_ring_ex, git: "https://github.com/whitehole-project/hash-ring-ex.git", branch: "master"},
       {:inch_ex, only: :docs}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule Discovery.Mixfile do
   defp deps do
     [
       {:consul, git: "https://github.com/cjimison/consul-ex.git", branch: "master"},
-      {:hash_ring_ex, git: "https://github.com/whitehole-project/hash-ring-ex.git", branch: "master"},
+      {:hash_ring_ex, git: "https://github.com/whitehole-project/hash-ring-ex.git", branch: "latest-elixir-support"},
       {:inch_ex, only: :docs}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Discovery.Mixfile do
     [
       app: :discovery,
       version: "0.5.7",
-      elixir: "~> 1.0 or ~> 0.15.1",
+      elixir: "~> 1.0",
       deps: deps,
       package: package,
       description: description
@@ -35,7 +35,7 @@ defmodule Discovery.Mixfile do
   defp deps do
     [
       {:consul, git: "https://github.com/cjimison/consul-ex.git", branch: "master"},
-      {:hash_ring_ex, "~> 1.1"},
+      {:hash_ring_ex, "~> 1.1.2"},
       {:inch_ex, only: :docs}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -5,10 +5,10 @@ defmodule Discovery.Mixfile do
     [
       app: :discovery,
       version: "0.5.7",
-      elixir: "~> 1.0",
-      deps: deps,
-      package: package,
-      description: description
+      elixir: "~> 1.4 or ~> 1.3 or ~> 1.0",
+      deps: deps(),
+      package: package(),
+      description: description()
     ]
   end
 


### PR DESCRIPTION
The idea here is I may have many VM's or other services defined where I don't want to modify the serviceX.json file for each.  With this change, if there is no tags or no otp_name defined it will assume that the otp_name should be Discovery.Node.name@Discovery.Node.Address.

I can see where this is very situational and it works for us, so you will not hurt my feelings if you reject this pull request :)
